### PR TITLE
feat(cashier): Add Firefox information for scanner support

### DIFF
--- a/docs/guides/registration/cashier/scanner.md
+++ b/docs/guides/registration/cashier/scanner.md
@@ -6,12 +6,13 @@ sidebar_position: 2
 
 Convention Cat's supported scanner is the [TEEMI 2D Barcode Scanner](https://www.amazon.com/gp/product/B074KH88Z7/ref=ppx_yo_dt_b_search_asin_title?ie=UTF8&th=1). The scanner behaves as a keyboard, and within the United States, it may scan attendees driver license to output into the search bar, to more quickly find the user, and verify their information.
 
-The scanner only works with Google Chrome or Microsoft Edge. Firefox does not suppport the web serial API, which is required for the scanner to work.
+The scanner only works with Google Chrome, Microsoft Edge, and Firefox\*. Safari does not suppport the web serial API, which is required for the scanner to work.
 
+_\* Firefox must be version 151 or later._
 
 # Configuring the TEEMI
 
-Scan the following barcodes with the TEEMI scanner to configure it to be used with the ConCat search bar: 
+Scan the following barcodes with the TEEMI scanner to configure it to be used with the ConCat search bar:
 
 <div>
   <ol>


### PR DESCRIPTION
Updates scanner support documentation as per https://hacks.mozilla.org/2026/05/web-serial-support-in-firefox/

<img width="1054" height="297" alt="image" src="https://github.com/user-attachments/assets/633884f5-9d0d-4aa1-80b9-adf045e779dc" />
